### PR TITLE
feat: freshness check child deps

### DIFF
--- a/examples/jaffle_shop/mart/order_items.py
+++ b/examples/jaffle_shop/mart/order_items.py
@@ -39,7 +39,7 @@ def mart_order_items(
             how="left",
         )
         .select(
-            *stage_order_items.columns,            
+            *stage_order_items.collect_schema().names(),            
             "product_name",
             "product_price",
             "is_food_item",

--- a/src/blueno/orchestration/blueprint.py
+++ b/src/blueno/orchestration/blueprint.py
@@ -712,7 +712,7 @@ class Blueprint(BaseJob):
         last_optimize = last_optimize.replace(tzinfo=timezone.utc)
 
         logger.info(
-            "%s was last optimized %s and the previous schudule is %s",
+            "%s was last optimized %s and the previous schedule is %s",
             self.name,
             last_optimize,
             prev_schedule,


### PR DESCRIPTION
improved freshness to check upstream dependencies recursively until it finds first table dependency - will always refresh if there are unresolved dependencies, e.g. if the blueprint is dependant on a blueprint which has no info on when it was last updated