### PR TITLE
feat: add blueprint cron schedule param

### DIFF
--- a/examples/jaffle_shop/raw.py
+++ b/examples/jaffle_shop/raw.py
@@ -1,5 +1,6 @@
 from blueno import Blueprint, DataFrameType
 import polars as pl
+from datetime import timedelta
 
 
 base_url = "https://dbt-tutorial-public.s3.us-west-2.amazonaws.com/long_term_dataset"
@@ -17,6 +18,9 @@ def raw_customers() -> DataFrameType:
 
 @Blueprint.register(
     table_uri=lakehouse_base_url + "items",
+    freshness=timedelta(hours=1),
+    schedule="* * * * 1-5",
+    maintenance_schedule="* * * * 6-7",
     format="delta",
 )
 def raw_order_items() -> DataFrameType:

--- a/src/blueno/orchestration/blueprint.py
+++ b/src/blueno/orchestration/blueprint.py
@@ -83,7 +83,7 @@ class Blueprint(BaseJob):
         deduplication_order_columns: Optional[List[str]] = None,
         priority: int = 100,
         max_concurrency: Optional[int] = None,
-        maintenance_schedule: Optional[int] = None,
+        maintenance_schedule: Optional[timedelta] = None,
         freshness: Optional[timedelta] = None,
         **kwargs,
     ):

--- a/src/blueno/utils/__init__.py
+++ b/src/blueno/utils/__init__.py
@@ -4,6 +4,7 @@ from blueno.utils.misc import quote_identifier, remove_none, separator_indices, 
 
 from .delta import (
     get_delta_table_if_exists,
+    get_delta_table_or_raise,
     get_last_modified_time,
     get_max_column_value,
     get_min_column_value,
@@ -20,6 +21,7 @@ __all__ = (
     "get_last_modified_time",
     "get_or_create_delta_table",
     "get_delta_table_if_exists",
+    "get_delta_table_or_raise",
     "separator_indices",
     "quote_identifier",
     "to_snake_case",

--- a/src/blueno/utils/delta.py
+++ b/src/blueno/utils/delta.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any
 
 import polars as pl
@@ -45,6 +45,22 @@ def get_delta_table_if_exists(table_uri: str) -> DeltaTable | None:
 
     if not DeltaTable.is_deltatable(table_uri, storage_options=storage_options):
         return None
+
+    dt = DeltaTable(table_uri, storage_options=storage_options)
+
+    return dt
+
+
+def get_delta_table_or_raise(table_uri: str) -> DeltaTable:
+    """Retrieves a Delta table. Raises exception if not exists.
+
+    Args:
+        table_uri: The URI of the Delta table.
+
+    Returns:
+        The Delta table.
+    """
+    storage_options = get_storage_options(table_uri)
 
     dt = DeltaTable(table_uri, storage_options=storage_options)
 
@@ -108,7 +124,7 @@ def get_last_modified_time(
     if timestamp is None:
         return None
 
-    return datetime.fromtimestamp(timestamp / 1000)
+    return datetime.fromtimestamp(timestamp / 1000, tz=timezone.utc)
 
 
 def get_max_column_value(table_or_uri: str | DeltaTable, column_name: str) -> Any:


### PR DESCRIPTION
- Adds a cron schedule param to the Blueprint. Users can now define a cron schedule for when a blueprint is allowed to run. For example, a blueprint with schedule `* * * * 1-5` will be only be run if blueno is ran on Mondays through Fridays.