### PR TITLE
feat: add new write modes safe append and naive upsert

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -147,3 +147,5 @@ target_table
 basic_example.parquet
 lakehouse
 data_generator
+jaffle_shop
+contoso

--- a/examples/jaffle_shop/mart/order_items.py
+++ b/examples/jaffle_shop/mart/order_items.py
@@ -5,6 +5,8 @@ import polars.selectors as cs
 @Blueprint.register(
     table_uri="jaffle_shop/mart/order_items",
     format="delta",
+    primary_keys=["order_item_id"],
+    write_mode="naive_upsert",
     maintenance_schedule="0 0 * * *",
 )
 def mart_order_items(

--- a/examples/jaffle_shop/mart/orders.py
+++ b/examples/jaffle_shop/mart/orders.py
@@ -4,7 +4,10 @@ import polars as pl
 
 @Blueprint.register(
     table_uri="jaffle_shop/mart/orders",
-    format="delta"
+    format="delta",
+    primary_keys=["order_id"],
+    write_mode="safe_append",
+    incremental_column="ordered_at",
 )
 def mart_orders(
     mart_order_items: DataFrameType,

--- a/examples/jaffle_shop/raw.py
+++ b/examples/jaffle_shop/raw.py
@@ -29,9 +29,14 @@ def raw_order_items() -> DataFrameType:
 
 @Blueprint.register(
     table_uri=lakehouse_base_url + "orders",
+    freshness=timedelta(hours=0),
+    schedule="* * * * 1-5",
+    maintenance_schedule="* * * * 6-7",    
     format="delta",
 )
 def raw_orders() -> DataFrameType:
+    import time
+    time.sleep(5)
     return pl.scan_csv(base_url + "/raw_orders.csv")
 
 

--- a/scripts/test_blueprint.py
+++ b/scripts/test_blueprint.py
@@ -1,0 +1,10 @@
+from blueno import job_registry
+from blueno.cli import run
+
+
+run(
+    project_dir="./examples/jaffle_shop",
+    select=["++mart_orders", "++mart_order_items"],
+    display_mode="log",
+    log_level="DEBUG"
+)

--- a/src/blueno/orchestration/blueprint.py
+++ b/src/blueno/orchestration/blueprint.py
@@ -493,7 +493,7 @@ class Blueprint(BaseJob):
                 table_or_uri=self.delta_table or self.table_uri,
                 df=self._dataframe,
                 key_columns=self.primary_keys,
-                predicate_exclusion_columns=[self.columns],
+                predicate_exclusion_columns=self.columns,
                 update_exclusion_columns=[self._identity_column, self._created_at_column],
             ),
             "incremental": lambda: incremental(

--- a/src/blueno/orchestration/pipeline.py
+++ b/src/blueno/orchestration/pipeline.py
@@ -239,10 +239,10 @@ class Pipeline:
                         done = [f for f in self._running_activities if f.done()]
                         if done:
                             break
-                        time.sleep(0.2)
+                        time.sleep(0.1)
 
                         if time.time() - last_printed > 2:
-                            cpu_percent = psutil.cpu_percent(interval=1)
+                            cpu_percent = psutil.cpu_percent(interval=0)
                             cpu_cores = psutil.cpu_count(logical=True)
 
                             virtual_mem = psutil.virtual_memory()

--- a/src/blueno/orchestration/pipeline.py
+++ b/src/blueno/orchestration/pipeline.py
@@ -239,9 +239,9 @@ class Pipeline:
                         done = [f for f in self._running_activities if f.done()]
                         if done:
                             break
-                        time.sleep(0.1)
+                        time.sleep(0.2)
 
-                        if time.time() - last_printed > 2.5:
+                        if time.time() - last_printed > 2:
                             cpu_percent = psutil.cpu_percent(interval=1)
                             cpu_cores = psutil.cpu_count(logical=True)
 
@@ -258,7 +258,6 @@ class Pipeline:
                                 mem_percent,
                             )
                             last_printed = time.time()
-
 
                     for future in done:
                         activity = self._running_activities.pop(future)

--- a/tests/fuzz/test_fuzz_blueprint.py
+++ b/tests/fuzz/test_fuzz_blueprint.py
@@ -15,8 +15,10 @@ from blueno.orchestration.blueprint import Blueprint
     write_mode=st.sampled_from(
         [
             "append",
+            "safe_append",
             "overwrite",
             "upsert",
+            "naive_upsert",
             "incremental",
             "replace_range",
             "scd2_by_column",
@@ -30,6 +32,8 @@ from blueno.orchestration.blueprint import Blueprint
     incremental_column=st.one_of(st.none(), st.text(min_size=1), st.lists(st.text(min_size=1), max_size=3)),
     scd2_column=st.one_of(st.none(), st.text(min_size=1), st.lists(st.text(min_size=1), max_size=3)),
     freshness=st.one_of(st.none(), st.timedeltas(), st.integers(), st.text()),
+    schedule=st.one_of(st.just("* * * * *"), st.just("* * * * * *"), st.just("not cron")),
+    maintenance_schedule=st.one_of(st.just("* * * * *"), st.just("* * * * * *"), st.just("not cron")),
     schema=st.one_of(st.none(), st.just(pl.Schema({"a": pl.Int64})), st.just(pl.Schema({"a": pl.String}))),
     post_transforms=st.lists(
         st.sampled_from(
@@ -46,7 +50,7 @@ from blueno.orchestration.blueprint import Blueprint
     ),
 )
 def test_blueprint_register_fuzz(
-    write_mode, format, primary_keys, incremental_column, scd2_column, freshness, post_transforms, deduplication_order_columns, schema
+    write_mode, format, primary_keys, incremental_column, scd2_column, freshness, post_transforms, deduplication_order_columns, schema, schedule, maintenance_schedule
 ):
     # Compose arguments
     kwargs = dict(
@@ -62,6 +66,8 @@ def test_blueprint_register_fuzz(
         format=format,
         freshness=freshness,
         post_transforms=post_transforms,
+        schedule=schedule,
+        maintenance_schedule=maintenance_schedule,
     )
 
     def dummy(self):


### PR DESCRIPTION
Added `safe_append` and `naive_upsert` write modes.
- safe append filters the source dataframe on by primary key and incremental column before appending it to the target table - this ensures appending is an idempotent operation for incremental loads.
- naive upsert is similar to regular upsert but instead of only updating rows if they have changes, it just updates any match on the primary keys - while this in theory creates more writes on the storage account, it should be a cheaper operation in terms of memory and cpu