### PR TITLE
feat: allow result cache

### DIFF
--- a/docs/learn/blueprints/introduction.md
+++ b/docs/learn/blueprints/introduction.md
@@ -353,7 +353,6 @@ class CustomBlueprint(Blueprint):
         write_deltalake(
             table_or_uri=self.table_uri,
             data=self._dataframe.to_arrow(),
-            partition_by=["date"],
             mode="overwrite",
             predicate=partition_predicate,
         )

--- a/src/blueno/etl/load/parquet.py
+++ b/src/blueno/etl/load/parquet.py
@@ -7,12 +7,11 @@ from blueno.types import DataFrameType
 
 
 def write_parquet(uri: str, df: DataFrameType) -> None:
-    """Overwrites the entire parquet file or directory (if using `partition_by`) with the provided dataframe.
+    """Overwrites the entire parquet file or directory with the provided dataframe.
 
     Args:
-        uri: The file or directory URI to write to. This should be a path if using `partition_by`
+        uri: The file or directory URI to write to.
         df: The dataframe to write
-        partition_by: Column(s) to partition by
 
     Example:
         ```python

--- a/src/blueno/orchestration/blueprint.py
+++ b/src/blueno/orchestration/blueprint.py
@@ -55,7 +55,6 @@ class Blueprint(BaseJob):
     post_transforms: List[str]
     deduplication_order_columns: List[str]
     primary_keys: List[str]
-    partition_by: List[str]
     incremental_column: Optional[str] = None
     scd2_column: Optional[str] = None
     freshness: Optional[timedelta] = None
@@ -77,7 +76,6 @@ class Blueprint(BaseJob):
         table_uri: Optional[str] = None,
         schema: Optional[pl.Schema] = None,
         primary_keys: Optional[List[str]] = None,
-        partition_by: Optional[List[str]] = None,
         incremental_column: Optional[str] = None,
         scd2_column: Optional[str] = None,
         write_mode: str = "overwrite",
@@ -105,7 +103,6 @@ class Blueprint(BaseJob):
             table_uri: The URI of the target table. If not provided, the blueprint will not be stored as a table.
             schema: The schema of the output dataframe. If provided, transformation function will be validated against this schema.
             primary_keys: The primary keys of the target table. Is required for `upsert` `naive_upsert` and `scd2_by_column` write_mode.
-            partition_by: The columns to partition the of the target table by.
             incremental_column: The incremental column for the target table. Is required for `incremental` and `safe_append` write mode.
             scd2_column: The name of the sequence column used for SCD2. Is required for `scd2_by_column` and `scd2_by_time` write mode.
             write_mode: The write method to use. Defaults to `overwrite`.
@@ -175,7 +172,6 @@ class Blueprint(BaseJob):
             name="gold_customer",
             table_uri="/path/to/gold/customer",
             primary_keys=["customer_id", "site_id"],
-            partition_by=["year", "month", "day"],
             incremental_column="order_timestamp",
             scd2_column="modified_timestamp",
             write_mode="upsert",
@@ -216,7 +212,6 @@ class Blueprint(BaseJob):
                 table_uri=table_uri,
                 schema=schema,
                 primary_keys=primary_keys or [],
-                partition_by=partition_by or [],
                 incremental_column=incremental_column,
                 scd2_column=scd2_column,
                 write_mode=write_mode,
@@ -688,7 +683,7 @@ class Blueprint(BaseJob):
             return
 
         if self.format == "parquet":
-            write_parquet(self.table_uri, self._dataframe, partition_by=self.partition_by)
+            write_parquet(self.table_uri, self._dataframe)
             return
 
         self._write_modes.get(self.write_mode)()

--- a/src/blueno/orchestration/job.py
+++ b/src/blueno/orchestration/job.py
@@ -273,7 +273,6 @@ class JobRegistry:
     #             # _transform_fn=local_vars.get("fn"),
     #             _transform_fn=wrapped_func,
     #             primary_keys=blueprint_config.get("primary_keys"),
-    #             partition_by=blueprint_config.get("partition_by"),
     #             incremental_column=blueprint_config.get("incremental_column"),
     #             valid_from_column=blueprint_config.get("valid_from_column"),
     #             valid_to_column=blueprint_config.get("valid_to_column"),

--- a/tests/blueprints/test_custom_blueprint.py
+++ b/tests/blueprints/test_custom_blueprint.py
@@ -47,7 +47,6 @@ def test_custom_blueprint():
             write_deltalake(
                 table_or_uri=self.table_uri,
                 data=self._dataframe,
-                partition_by=["date"],
                 mode="overwrite",
                 predicate=partition_predicate,
             )

--- a/tests/fuzz/test_fuzz_blueprint.py
+++ b/tests/fuzz/test_fuzz_blueprint.py
@@ -58,7 +58,6 @@ def test_blueprint_register_fuzz(
         table_uri="/tmp/fuzz" if format != "dataframe" else None,
         schema=schema,
         primary_keys=primary_keys,
-        partition_by=[],
         incremental_column=incremental_column,
         deduplication_order_columns=deduplication_order_columns,
         scd2_column=scd2_column,


### PR DESCRIPTION
Adds caching mechanism by providing `cache_mode` to the `Blueprint.register()` function. It should be either `memory` or `file`. If not set, nothing will be cached. If set to `memory` the dataframe produced by the user-defined transformations will be cached in-memory. If set to `file` the cache is instead stored as `.parquet` file in the `table_uri` destination folder. The cacheefore each run, however it is overwritten on subsequent runs (file cache only). 