### PR TITLE
fix: memory caching bug

### DIFF
--- a/src/blueno/orchestration/blueprint.py
+++ b/src/blueno/orchestration/blueprint.py
@@ -1102,7 +1102,7 @@ class Blueprint(BaseJob):
             self._dataframe = read_parquet(cache_file)
 
         elif self.cache_mode.lower() == "memory":
-            self._dataframe.lazy().collect(engine="streaming")
+            self._dataframe = self._dataframe.lazy().collect(engine="streaming")
 
         else:
             raise BluenoUserError(


### PR DESCRIPTION
Fixed a  bug where the `cache_mode=memory` didn't properly use the cached dataframe.